### PR TITLE
Support snyk not installed

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,5 +11,6 @@ func main() {
 	rootCmd := cmd.GetRootCommand()
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Support Snyk not installed:

We changed the recommended approach from having Snyk package installed globally (`npm install -g snyk`) to using npx (`npx snyk cmd`).

This PR parametrizes the command that is run - specifically you can pass `--snyk-cmd=npx snyk` to make this utility run `npx snyk` rather than just `snyk`.

Also, as a bonus, sets the non-zero exit code on error.


## Testing:

Before was exiting with code 0, now 1:
```
//"args": ["--org=orgTest", "--product=prodTest", "--version=1.1.1.1"]

Error: exec: "snyk": executable file not found in %PATH%
Usage:
  snyk-history-scanner [flags]

Flags:
      --debug             run in debug mode
      --dotnet            if dotnet projects should be scanned
      --exclude strings   pass --exclude multiple times to exclude these directories (must be relative to where you're running this cli from)
      --golang            if golang projects should be scanned
  -h, --help              help for snyk-history-scanner
      --java              if java projects should be scanned
      --npm               if npm projects should be scanned
      --org string        the snyk organisation this scan should be a part of
      --product string    the name of the product being scanned
      --snyk-cmd string   the command to run Snyk, i.e. 'npx snyk' (default "snyk")
      --version string    the version of the product being scanned

exec: "snyk": executable file not found in %PATH%
Process exiting with code: 1 signal: false
```

When run with `snyk-cmd` set:
```
//"args": ["--org=orgTest", "--product=prodTest", "--version=1.1.1.1", "--snyk-cmd=npx snyk", "--debug"]

time="2021-05-20T15:47:28+01:00" level=debug msg="using cmd 'npx snyk'"
time="2021-05-20T15:47:28+01:00" level=debug msg="working dir is 'c:\\Code\\snyk-history-scanner'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner'"
time="2021-05-20T15:47:28+01:00" level=debug msg="skipping 'c:\\Code\\snyk-history-scanner\\.git' as it is excluded"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\.github'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\.github\\workflows'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\.github\\workflows\\release.yaml'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\.gitignore'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\.vscode'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\.vscode\\launch.json'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\LICENSE'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\README.md'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\__debug_bin'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\cmd'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\cmd\\root.go'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\go.mod'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\go.sum'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\main.go'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\pkg'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\pkg\\dotnet.go'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\pkg\\golang.go'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\pkg\\java.go'"
time="2021-05-20T15:47:28+01:00" level=debug msg="inspecting file 'c:\\Code\\snyk-history-scanner\\pkg\\javascript.go'"
Process exiting with code: 0

```
