### PR TITLE
Pass cmd args properly

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,16 +64,15 @@ func execute(opts options, snykArgs []string) error {
 	dirExcludes := defaultDirExcludes
 	dirExcludes = append(dirExcludes, opts.excludedDirs...)
 	manifests := getManifests(opts)
+	cmdFields := strings.Fields(opts.snykCmd)
+	cmd :=cmdFields[0];
+	cmdArgs :=cmdFields[1:];
 
-	if (opts.snykCmd == "snyk")	{
-		_, err := exec.LookPath("snyk")
-		if err != nil {
-			return err
-		}
-		log.Debug("found snyk cli on path")
-	} else {
-		log.Debugf("using cmd '%s'", opts.snykCmd)
+	_, err := exec.LookPath(cmd)
+	if err != nil {
+		return err
 	}
+	log.Debugf("found '%s' on path", cmd)
 
 	workingDir, err := os.Getwd()
 	if err != nil {
@@ -98,7 +97,7 @@ func execute(opts options, snykArgs []string) error {
 				fmt.Printf("scanning '%s' with snyk...\n", path)
 				log.Debugf("file '%s' was manifest match", path)
 				manifestRelativePath := getManifestRelativePath(workingDir, path)
-				err := runSnykMonitor(manifestRelativePath, opts.productName, manifestRelativePath, opts.productVersion, opts.snykOrg, opts.snykCmd, snykArgs)
+				err := runSnykMonitor(manifestRelativePath, opts.productName, manifestRelativePath, opts.productVersion, opts.snykOrg, cmd, cmdArgs, snykArgs)
 				if err != nil {
 					return err
 				}
@@ -110,8 +109,9 @@ func execute(opts options, snykArgs []string) error {
 	return err
 }
 
-func runSnykMonitor(file, productName, projectName, version, snykOrg string, snykCmd string, extraArgs []string) error {
+func runSnykMonitor(file, productName, projectName, version, snykOrg string, snykCmd string, cmdArgs []string, extraArgs []string) error {
 	args := []string{"monitor", fmt.Sprintf("--file=%s", file), fmt.Sprintf("--project-name=%s@%s", projectName, version), fmt.Sprintf("--remote-repo-url=%s@%s", productName, version), fmt.Sprintf("--org=%s", snykOrg)}
+	args = append(cmdArgs, args...)
 	args = append(args, extraArgs...)
 
 	fmt.Printf("running '%s %s'\n", snykCmd, strings.Join(args, " "))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,8 +65,8 @@ func execute(opts options, snykArgs []string) error {
 	dirExcludes = append(dirExcludes, opts.excludedDirs...)
 	manifests := getManifests(opts)
 	cmdFields := strings.Fields(opts.snykCmd)
-	cmd :=cmdFields[0];
-	cmdArgs :=cmdFields[1:];
+	cmd := cmdFields[0]
+	cmdArgs := cmdFields[1:]
 
 	_, err := exec.LookPath(cmd)
 	if err != nil {


### PR DESCRIPTION
Fix after #2...

It's to fix `exec: "npx snyk": executable file not found in %PATH%`...

## Tested:
```
/// "args": ["--org=orgTest", "--product=prodTest", "--version=1.1.1.1", "--snyk-cmd=npx snyk", "--debug", "--golang"]

scanning 'c:\Code\snyk-history-scanner\go.mod' with snyk...
running 'npx snyk monitor --file=go.mod --project-name=go.mod@1.1.1.1 --remote-repo-url=prodTest@1.1.1.1 --org=orgTest'

Monitoring c:\Code\snyk-history-scanner...

Org orgTest was not found or you may not have the correct permissions to access the org. Try re-running with the `--org` flag.
You can use the following orgs: compare-for-oracle-current, compare-for-oracle-released-versions, data-masker-current, data-masker-released-versions, flyway-current, flyway-released-versions, platform-current, platform-released-versions, rcx-current, rcx-released-versions, spawn, spawn-released-versions, sql-clone-current, sql-clone-released-versions, sql-compare-current, sql-compare-released-versions, sql-data-catalog-current, sql-data-catalog-released-versions, sql-monitor-current, sql-monitor-released-versions, sql-prompt-current, sql-prompt-released-versions, sql-search-current, sql-search-released-versions.


Error: exit status 2

```