### PR TITLE
If a file is excluded, only ignore that file not the containing directory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+name: Build & Test
+on: [pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.6'
+      - name: Build multi-arch
+        run: |
+          GOOS=windows GOARCH=amd64 go build -o snyk-history-scanner.exe
+          GOOS=darwin GOARCH=amd64 go build -o snyk-history-scanner-darwin
+          GOOS=linux GOARCH=amd64 go build -o snyk-history-scanner-linux
+  test:
+    needs: build
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.6'
+      - name: Build multi-arch
+        run: |
+          go test ./...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,37 +25,38 @@ type options struct {
 	debug          bool
 }
 
+var opts = options{}
+
 var defaultDirExcludes = []string{
 	"node_modules",
 	".git",
 }
 
 func GetRootCommand() *cobra.Command {
-	options := options{}
 	cmd := &cobra.Command{
 		Use:   "snyk-history-scanner",
 		Short: "A very thin wrapper around the Snyk CLI tool to make it possible to monitor old releases of versions.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if options.debug {
+			if opts.debug {
 				log.SetLevel(log.DebugLevel)
 			}
-			return execute(options, args)
+			return execute(opts, args)
 		},
 	}
-	cmd.Flags().StringVar(&options.productName, "product", "", "the name of the product being scanned")
-	cmd.Flags().StringVar(&options.productVersion, "version", "", "the version of the product being scanned")
-	cmd.Flags().StringVar(&options.snykOrg, "org", "", "the snyk organisation this scan should be a part of")
+	cmd.Flags().StringVar(&opts.productName, "product", "", "the name of the product being scanned")
+	cmd.Flags().StringVar(&opts.productVersion, "version", "", "the version of the product being scanned")
+	cmd.Flags().StringVar(&opts.snykOrg, "org", "", "the snyk organisation this scan should be a part of")
 	cmd.MarkFlagRequired("product")
 	cmd.MarkFlagRequired("version")
 	cmd.MarkFlagRequired("org")
 
-	cmd.Flags().BoolVar(&options.dotnet, "dotnet", false, "if dotnet projects should be scanned")
-	cmd.Flags().BoolVar(&options.golang, "golang", false, "if golang projects should be scanned")
-	cmd.Flags().BoolVar(&options.java, "java", false, "if java projects should be scanned")
-	cmd.Flags().BoolVar(&options.javascript, "npm", false, "if npm projects should be scanned")
-	cmd.Flags().StringSliceVar(&options.excludedDirs, "exclude", []string{}, "pass --exclude multiple times to exclude these directories/files (must be relative to where you're running this cli from)")
-	cmd.Flags().StringVar(&options.snykCmd, "snyk-cmd", "snyk", "the command to run Snyk, i.e. 'npx snyk'")
-	cmd.Flags().BoolVar(&options.debug, "debug", false, "run in debug mode")
+	cmd.Flags().BoolVar(&opts.dotnet, "dotnet", false, "if dotnet projects should be scanned")
+	cmd.Flags().BoolVar(&opts.golang, "golang", false, "if golang projects should be scanned")
+	cmd.Flags().BoolVar(&opts.java, "java", false, "if java projects should be scanned")
+	cmd.Flags().BoolVar(&opts.javascript, "npm", false, "if npm projects should be scanned")
+	cmd.Flags().StringSliceVar(&opts.exclusions, "exclude", []string{}, "pass --exclude multiple times to exclude these directories/files (must be relative to where you're running this cli from)")
+	cmd.Flags().StringVar(&opts.snykCmd, "snyk-cmd", "snyk", "the command to run Snyk, i.e. 'npx snyk'")
+	cmd.Flags().BoolVar(&opts.debug, "debug", false, "run in debug mode")
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ type options struct {
 	golang         bool
 	java           bool
 	javascript     bool
-	excludedDirs   []string
+	exclusions     []string
 	snykOrg        string
 	productName    string
 	productVersion string
@@ -53,7 +53,7 @@ func GetRootCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&options.golang, "golang", false, "if golang projects should be scanned")
 	cmd.Flags().BoolVar(&options.java, "java", false, "if java projects should be scanned")
 	cmd.Flags().BoolVar(&options.javascript, "npm", false, "if npm projects should be scanned")
-	cmd.Flags().StringSliceVar(&options.excludedDirs, "exclude", []string{}, "pass --exclude multiple times to exclude these directories (must be relative to where you're running this cli from)")
+	cmd.Flags().StringSliceVar(&options.excludedDirs, "exclude", []string{}, "pass --exclude multiple times to exclude these directories/files (must be relative to where you're running this cli from)")
 	cmd.Flags().StringVar(&options.snykCmd, "snyk-cmd", "snyk", "the command to run Snyk, i.e. 'npx snyk'")
 	cmd.Flags().BoolVar(&options.debug, "debug", false, "run in debug mode")
 
@@ -61,8 +61,8 @@ func GetRootCommand() *cobra.Command {
 }
 
 func execute(opts options, snykArgs []string) error {
-	dirExcludes := defaultDirExcludes
-	dirExcludes = append(dirExcludes, opts.excludedDirs...)
+	exclusions := defaultDirExcludes
+	exclusions = append(exclusions, opts.exclusions...)
 	manifests := getManifests(opts)
 	cmdFields := strings.Fields(opts.snykCmd)
 	cmd := cmdFields[0]
@@ -86,7 +86,7 @@ func execute(opts options, snykArgs []string) error {
 				return err
 			}
 
-			if in(info.Name(), dirExcludes) {
+			if in(info.Name(), exclusions) {
 				log.Debugf("skipping '%s' as it is excluded", path)
 				return filepath.SkipDir
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,8 +88,12 @@ func execute(opts options, snykArgs []string) error {
 			}
 
 			if in(info.Name(), exclusions) {
-				log.Debugf("skipping '%s' as it is excluded", path)
-				return filepath.SkipDir
+				if info.IsDir() {
+					log.Debugf("skipping directory '%s' as it is excluded", path)
+					return filepath.SkipDir
+				}
+				log.Debugf("skipping file '%s' as it is excluded", path)
+				return nil
 			}
 
 			log.Debugf("inspecting file '%s'", path)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestFileExclusionsOnlyExcludeFile_NotContainingDirectory(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("couldnt get working dir: %s", err)
+	}
+
+	subdir := filepath.Join(workingDir, "sub1")
+
+	err = os.Mkdir(subdir, 0755)
+	if err != nil {
+		t.Fatalf("couldnt create subdir: %s", err)
+	}
+	defer func() {
+		os.RemoveAll(subdir)
+	}()
+
+	_, err = os.Create(filepath.Join(subdir, "package.json"))
+	if err != nil {
+		t.Fatalf("couldnt create package.json in subdir: %s", err)
+	}
+	yarnLockPath := filepath.Join(subdir, "yarn.lock")
+	_, err = os.Create(yarnLockPath)
+	if err != nil {
+		t.Fatalf("couldnt create yarn.lock in subdir: %s", err)
+	}
+
+	rootCmd := GetRootCommand()
+
+	rootCmd.SetArgs([]string{"--product=foo", "--version=1", "--org=bar", "--exclude=package.json", "--snyk-cmd=true", "--npm", "--debug"})
+	rootCmd.Execute()
+
+	logOutput := buf.String()
+	t.Log(logOutput)
+	if !strings.Contains(logOutput, fmt.Sprintf("file '%s' was manifest match", yarnLockPath)) {
+		t.Errorf("did not scan yarn lock, but should have done")
+	}
+}


### PR DESCRIPTION
If a file was excluded, we were inadvertently ignoring containing subdirectory rather than just the file.